### PR TITLE
Process javascript files in deterministic (alphabetical) order

### DIFF
--- a/lib/sproutcore/compiler/preprocessors/java_script.rb
+++ b/lib/sproutcore/compiler/preprocessors/java_script.rb
@@ -14,7 +14,7 @@ module SproutCore
       class JavaScriptTask < Rake::FileTask
         # Create a series of Preprocessor tasks for the inputs
         def self.with_input(glob, package_root)
-          Dir[File.join(package_root, glob)].map do |input|
+          Dir[File.join(package_root, glob)].sort.map do |input|
             output = output_location(input, package_root)
 
             # Create a new Preprocessor task to convert the raw input into


### PR DESCRIPTION
With this change the generated sproutcore.js is bit-for-bit identical on Linux and Mac.
